### PR TITLE
Add a published_in method to Aptly::Snapshot like we have in Aptly:Repository

### DIFF
--- a/lib/aptly/publishable.rb
+++ b/lib/aptly/publishable.rb
@@ -1,0 +1,26 @@
+module Aptly
+  module Publishable
+    # Lists all PublishedRepositories self is published in. Namely self must
+    # be a source of the published repository in order for it to appear here.
+    # This method always returns an array of affected published repositories.
+    # If you use this method with a block it will additionally yield each
+    # published repository that would appear in the array, making it a shorthand
+    # for {Array#each}.
+    # @yieldparam pub [PublishedRepository]
+    # @return [Array<PublishedRepository>]
+    def published_in
+      Aptly::PublishedRepository.list(connection).select do |pub|
+        next false unless pub.Sources.any? do |src|
+          src.Name == self.Name
+        end
+        yield pub if block_given?
+        true
+      end
+    end
+
+    # @return [Boolean]
+    def published?
+      !published_in.empty?
+    end
+  end
+end

--- a/lib/aptly/repository.rb
+++ b/lib/aptly/repository.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require_relative 'errors'
 require_relative 'representation'
 require_relative 'snapshot'
+require_relative 'publishable'
 
 module Aptly
   # Aptly repository representation.

--- a/lib/aptly/repository.rb
+++ b/lib/aptly/repository.rb
@@ -9,6 +9,8 @@ module Aptly
   # Aptly repository representation.
   # @see http://www.aptly.info/doc/api/repos/
   class Repository < Representation
+    include Publishable
+
     # Delete this repository.
     def delete(**kwords)
       connection.send(:delete, "/repos/#{self.Name}", query: kwords)
@@ -76,29 +78,6 @@ module Aptly
     # @return [PublishedRepository] newly published repository
     def publish(prefix, **kwords)
       Aptly.publish([{ Name: self.Name }], prefix, 'local', kwords)
-    end
-
-    # @return [Boolean]
-    def published?
-      !published_in.empty?
-    end
-
-    # Lists all PublishedRepositories self is published in. Namely self must
-    # be a source of the published repository in order for it to appear here.
-    # This method always returns an array of affected published repositories.
-    # If you use this method with a block it will additionally yield each
-    # published repository that would appear in the array, making it a shorthand
-    # for {Array#each}.
-    # @yieldparam pub [PublishedRepository]
-    # @return [Array<PublishedRepository>]
-    def published_in
-      Aptly::PublishedRepository.list(connection).select do |pub|
-        next false unless pub.Sources.any? do |src|
-          src.Name == self.Name
-        end
-        yield pub if block_given?
-        true
-      end
     end
 
     # Edit this repository's attributes as per the parameters.

--- a/lib/aptly/snapshot.rb
+++ b/lib/aptly/snapshot.rb
@@ -50,6 +50,23 @@ module Aptly
       Aptly.publish([{ Name: self.Name }], prefix, 'snapshot', kwords)
     end
 
+    # Lists all PublishedRepositories self is published in. Namely self must
+    # be a source of the published repository in order for it to appear here.
+    # This method always returns an array of affected published repositories.
+    # If you use this method with a block it will additionally yield each
+    # published repository that would appear in the array, making it a shorthand
+    # for {Array#each}.
+    # @yieldparam pub [PublishedRepository]
+    # @return [Array<PublishedRepository>]
+    def published_in
+      Aptly::PublishedRepository.list(connection).select do |pub|
+        next false unless pub.Sources.any? do |src|
+          src.Name == self.Name
+        end
+        yield pub if block_given?
+        true
+      end
+    end
 
     class << self
       # List all known snapshots.

--- a/lib/aptly/snapshot.rb
+++ b/lib/aptly/snapshot.rb
@@ -1,9 +1,11 @@
 require_relative 'representation'
-
+require_relative 'publishable'
 module Aptly
   # Aptly snapshots representation.
   # @see http://www.aptly.info/doc/api/snapshots/
   class Snapshot < Representation
+    include Publishable
+
     # Updates this snapshot
     # @return [self] if the instance data was mutated
     # @return [nil] if the instance data was not mutated
@@ -48,24 +50,6 @@ module Aptly
     # @return [PublishedRepository] newly published repository
     def publish(prefix, **kwords)
       Aptly.publish([{ Name: self.Name }], prefix, 'snapshot', kwords)
-    end
-
-    # Lists all PublishedRepositories self is published in. Namely self must
-    # be a source of the published repository in order for it to appear here.
-    # This method always returns an array of affected published repositories.
-    # If you use this method with a block it will additionally yield each
-    # published repository that would appear in the array, making it a shorthand
-    # for {Array#each}.
-    # @yieldparam pub [PublishedRepository]
-    # @return [Array<PublishedRepository>]
-    def published_in
-      Aptly::PublishedRepository.list(connection).select do |pub|
-        next false unless pub.Sources.any? do |src|
-          src.Name == self.Name
-        end
-        yield pub if block_given?
-        true
-      end
     end
 
     class << self

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -151,6 +151,7 @@ class RepositoryTest < Minitest::Test
     pub = snapshot.publish('pony', Distribution: 'distro', Architectures: %w(source), Signing: { Skip: true })
     refute_nil(pub)
     assert_equal('pony', pub.Prefix)
+    assert_equal([pub], snapshot.published_in)
   end
 
   def test_x

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -100,4 +100,19 @@ class SnapshotTest < Minitest::Test
     assert_equal 'kewl-repo-name', pub.Prefix
     assert_equal %w(source), pub.Architectures
   end
+
+  def test_published_in
+    stub_request(:get, 'http://localhost/api/publish')
+      .to_return(body: "[{\"Architectures\":[\"all\"],\"Distribution\":\"distro\",\"Label\":\"\",\"Origin\":\"\",\"Prefix\":\"kewl-repo-name\",\"SourceKind\":\"snapshot\",\"Sources\":[{\"Component\":\"main\",\"Name\":\"kitten\"}],\"Storage\":\"\"}]\n")
+    repo = ::Aptly::Snapshot.new(::Aptly::Connection.new, Name: 'kitten')
+
+    # returns array
+    pubs = repo.published_in
+    assert 1, pubs.size
+    yielded = false
+
+    # yields with block
+    repo.published_in.each { yielded = true }
+    assert yielded
+  end
 end


### PR DESCRIPTION
Add a published_in method to Aptly::Snapshot like we have in Aptly:Repository
