### PR TITLE
deprecate uri construction by using uris for configuration

### DIFF
--- a/lib/aptly/configuration.rb
+++ b/lib/aptly/configuration.rb
@@ -1,36 +1,63 @@
+require 'rubygems/deprecate'
+
 module Aptly
   # Configuration.
   class Configuration
-    # @!attribute host
-    #   @return [String] host name to talk to
-    attr_accessor :host
+    extend Gem::Deprecate
 
-    # @!attribute port
-    #   @return [Integer] port to talk to host to on
-    attr_accessor :port
-
-    # @!attribute path
-    #   @return [String] path to use (defaults to /)
-    attr_accessor :path
+    # @!attribute uri
+    #   @return [URI] the base URI for the API (http://localhost by default)
+    attr_accessor :uri
 
     # Creates a new instance.
-    # @param host see {#host}
-    # @param port see {#port}
-    def initialize(host: 'localhost', port: 80, path: '/')
-      @host = host
-      @port = port
-      @path = path
+    # @param uri see {#uri}
+    # @param host DEPRECATED use uri
+    # @param port DEPRECATED use uri
+    # @param path DEPRECATED use uri
+    def initialize(uri: URI::HTTP.build(host: 'localhost',
+                                        port: 80,
+                                        path: '/'),
+                   host: nil, port: nil, path: nil)
+      @uri = uri unless host || port || path
+      return if @uri
+      @uri = fallback_uri(host, port, path)
     end
 
-    def uri
-      # FIXME: maybe we should simply configure a URI instead of configuring
-      #   each part?
-      uri = URI.parse('')
-      uri.scheme = 'http'
-      uri.host = host
-      uri.port = port
-      uri.path = path
-      uri
+    # @!attribute host
+    #   @deprecated use {#uri}
+    #   @return [String] host name to talk to
+
+    # @!attribute port
+    #   @deprecated use {#uri}
+    #   @return [Integer] port to talk to host to on
+
+    # @!attribute path
+    #   @deprecated use {#uri}
+    #   @return [String] path to use (defaults to /)
+
+    # Fake deprecated attributes and redirect them to @uri
+    [:host, :port, :path].each do |uri_attr|
+      define_method(uri_attr.to_s) do
+        @uri.send(uri_attr)
+      end
+      deprecate uri_attr, :uri, 2017, 1
+      define_method("#{uri_attr}=") do |x|
+        # Ruby < 2.3 does not manage to handle string ports, so we need
+        # to manually convert to integer.
+        @uri.send("#{uri_attr}=", uri_attr == :port ? safe_port(x) : x)
+      end
+      deprecate "#{uri_attr}=".to_sym, :uri, 2017, 1
+    end
+
+    private
+
+    def safe_port(port)
+      port ? port.to_i : port
+    end
+
+    def fallback_uri(host, port, path)
+      URI::HTTP.build(host: host || 'localhost', port: safe_port(port || 80),
+                      path: path || '/')
     end
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -10,7 +10,7 @@ class AptlyConfigurationTest < Minitest::Test
     refute_nil config.path
   end
 
-  def test_init_options
+  def test_init_options # deprecated in favor of uri
     config = ::Aptly::Configuration.new(host: 'otherhost',
                                         port: 9055,
                                         path: '/abc')
@@ -20,5 +20,23 @@ class AptlyConfigurationTest < Minitest::Test
     assert_equal(config.port, 9055)
     assert_equal(config.path, '/abc')
     assert_equal(config.uri.to_s, 'http://otherhost:9055/abc')
+  end
+
+  # partially providing deprecated params should construct a full uri
+  params = { host: 'otherhost', port: 9055, path: '/abc' }
+  params.each do |key, value|
+    define_method("test_fallback_compat_#{key}") do
+    config = ::Aptly::Configuration.new(key => value)
+    reference_params = { host: 'localhost', port: 80, path: '/' }
+    reference_params[key] = value
+    reference = URI::HTTP.build(reference_params)
+    assert_equal(reference, config.uri)
+    end
+  end
+
+  def test_init_uri
+    uri = URI.parse('https://example.com:123/xyz')
+    config = ::Aptly::Configuration.new(uri: uri)
+    assert_equal(uri, config.uri)
   end
 end


### PR DESCRIPTION
URI being a standardized url is a superset of what we need/want to support
for configuration WRT host access, so we can simply use URI as config
is largely replicating URI anyway and ultimately falling back to
constructing one

this is fully backwards compatible, albeit old stuff is marked deprecated.

the preferred way of configuration is now
```
Aptly.configure { |c| c.uri = URI::HTTP.build(host: 'api.example.com')) }
```

Setting the deprecated attributes still works but now passes the call
through to the internal URI