### PR TITLE
Add a method to publish a list of repos to a prefix

### DIFF
--- a/lib/aptly/publish.rb
+++ b/lib/aptly/publish.rb
@@ -50,7 +50,7 @@ module Aptly
       # @return [PublishedRepository] newly published repository
       def from_repositories(repos, prefix, **kwords)
         sources = repos.collect do |x|
-          { Name: x.Name, Component: x.DefaultComponent }
+          { Name: x.Name }
         end
         Aptly.publish(sources, prefix, **kwords)
       end

--- a/lib/aptly/publish.rb
+++ b/lib/aptly/publish.rb
@@ -43,7 +43,7 @@ module Aptly
         JSON.parse(response.body).collect { |h| new(connection, h) }
       end
 
-      # Publish a [Array<PublishedRepository>] list of repositories to a prefix
+      # Publish a [Array<Repoistory>] list of repositories to a prefix
       # @param sources [Array<Repository>] array of repositories to source
       # @param prefix [String] the prefix to publish under (must be escaped see
       #    {#escape_prefix})

--- a/lib/aptly/publish.rb
+++ b/lib/aptly/publish.rb
@@ -42,6 +42,18 @@ module Aptly
                                    query: kwords)
         JSON.parse(response.body).collect { |h| new(connection, h) }
       end
+
+      # Publish a [Array<PublishedRepository>] list of repositories to a prefix
+      # @param sources [Array<Repository>] array of repositories to source
+      # @param prefix [String] the prefix to publish under (must be escaped see
+      #    {#escape_prefix})
+      # @return [PublishedRepository] newly published repository
+      def from_repositories(repos, prefix, **kwords)
+        sources = repos.collect do |x|
+          { Name: x.Name, Component: x.DefaultComponent }
+        end
+        Aptly.publish(sources, prefix, **kwords)
+      end
     end
 
     private

--- a/lib/aptly/publish.rb
+++ b/lib/aptly/publish.rb
@@ -49,9 +49,7 @@ module Aptly
       #    {#escape_prefix})
       # @return [PublishedRepository] newly published repository
       def from_repositories(repos, prefix, **kwords)
-        sources = repos.collect do |x|
-          { Name: x.Name }
-        end
+        sources = repos.collect { |x| { Name: x.Name } }
         Aptly.publish(sources, prefix, **kwords)
       end
     end

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -109,6 +109,7 @@ class RepositoryTest < Minitest::Test
     assert_equal 'wily', pub.Distribution
     assert_equal %w[amd64], pub.Architectures
     assert_equal %w[kitten puppy] , pub.Sources.collect(&:Name).sort
+    assert_equal %w[kitten puppy] , pub.Sources.collect(&:Component).sort
     assert pub.Sources[0].is_a? ::Aptly::Repository
 
     assert kittenRepo.published?

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -99,10 +99,28 @@ class RepositoryTest < Minitest::Test
     refute repo.published_in.empty?
   end
 
+  def test_eee_repo_publish_multi
+    kittenRepo = ::Aptly::Repository.get('kitten')
+    kittenRepo.edit!(DefaultComponent: 'kitten')
+    puppyRepo = ::Aptly::Repository.create('puppy', DefaultComponent: 'puppy')
+    pub = Aptly::PublishedRepository.from_repositories([kittenRepo, puppyRepo], 'kewl-repo-name', Distribution: 'wily', Architectures: %w[amd64], Signing: { Skip: true })
+
+    assert pub.is_a? ::Aptly::PublishedRepository
+    assert_equal 'wily', pub.Distribution
+    assert_equal %w[amd64], pub.Architectures
+    assert_equal %w[kitten puppy] , pub.Sources.collect(&:Name).sort
+    assert pub.Sources[0].is_a? ::Aptly::Repository
+
+    assert kittenRepo.published?
+    assert puppyRepo.published?
+    refute kittenRepo.published_in.empty?
+    refute puppyRepo.published_in.empty?
+  end
+
   def test_fff_repo_list
     list = ::Aptly::Repository.list
 
-    assert_equal(1, list.size)
+    assert_equal(2, list.size)
     assert(list[0].is_a?(::Aptly::Repository))
     assert_equal('kitten', list[0].Name)
   end

--- a/test/publish_test.rb
+++ b/test/publish_test.rb
@@ -73,6 +73,7 @@ class PublishTest < Minitest::Test
   assert_equal 'kewl-repo-name', pub.Prefix
   assert_equal %w[source], pub.Architectures
   assert_equal %w[kitten puppy], pub.Sources.collect(&:Component)
+  assert_equal %w[kitten puppy], pub.Sources.collect(&:Name)
   end
 
   def test_s3_update!

--- a/test/publish_test.rb
+++ b/test/publish_test.rb
@@ -61,7 +61,7 @@ class PublishTest < Minitest::Test
 
   def test_publish_from_repositories
     stub_request(:post, 'http://localhost/api/publish/kewl-repo-name')
-    .with(body: '{"Distribution":"distro","Architectures":["source"],"Signing":{"Skip":true},"SourceKind":"local","Sources":[{"Name":"kitten","Component":"kitten"},{"Name":"puppy","Component":"puppy"}]}',
+    .with(body: '{"Distribution":"distro","Architectures":["source"],"Signing":{"Skip":true},"SourceKind":"local","Sources":[{"Name":"kitten"},{"Name":"puppy"}]}',
           headers: { 'Content-Type' => 'application/json' })
     .to_return(body: "{\"Architectures\":[\"source\"],\"Distribution\":\"distro\",\"Label\":\"\",\"Origin\":\"\",\"Prefix\":\"kewl-repo-name\",\"SourceKind\":\"local\",\"Sources\":[{\"Component\":\"kitten\",\"Name\":\"kitten\"}, {\"Component\":\"puppy\",\"Name\":\"puppy\"}],\"Storage\":\"\"}\n")
   kittenRepo = ::Aptly::Repository.new(::Aptly::Connection.new, Name: 'kitten', DefaultComponent: 'kitten')

--- a/test/publish_test.rb
+++ b/test/publish_test.rb
@@ -59,6 +59,22 @@ class PublishTest < Minitest::Test
     assert_equal('lab-eel', @pub.Label)
   end
 
+  def test_publish_from_repositories
+    stub_request(:post, 'http://localhost/api/publish/kewl-repo-name')
+    .with(body: '{"Distribution":"distro","Architectures":["source"],"Signing":{"Skip":true},"SourceKind":"local","Sources":[{"Name":"kitten","Component":"kitten"},{"Name":"puppy","Component":"puppy"}]}',
+          headers: { 'Content-Type' => 'application/json' })
+    .to_return(body: "{\"Architectures\":[\"source\"],\"Distribution\":\"distro\",\"Label\":\"\",\"Origin\":\"\",\"Prefix\":\"kewl-repo-name\",\"SourceKind\":\"local\",\"Sources\":[{\"Component\":\"kitten\",\"Name\":\"kitten\"}, {\"Component\":\"puppy\",\"Name\":\"puppy\"}],\"Storage\":\"\"}\n")
+  kittenRepo = ::Aptly::Repository.new(::Aptly::Connection.new, Name: 'kitten', DefaultComponent: 'kitten')
+  puppyRepo = ::Aptly::Repository.new(::Aptly::Connection.new, Name: 'puppy', DefaultComponent: 'puppy')
+  pub = Aptly::PublishedRepository.from_repositories([kittenRepo, puppyRepo], 'kewl-repo-name', Distribution: 'distro', Architectures: %w[source], Signing: { Skip: true })
+
+  assert pub.is_a?(::Aptly::PublishedRepository)
+  assert_equal 'distro', pub.Distribution
+  assert_equal 'kewl-repo-name', pub.Prefix
+  assert_equal %w[source], pub.Architectures
+  assert_equal %w[kitten puppy], pub.Sources.collect(&:Component)
+  end
+
   def test_s3_update!
     ret_hash = @pub_s3.marshal_dump.dup
     ret_hash[:Sources] = [{ 'Component' => 'main', 'Name' => 'puppies' }]


### PR DESCRIPTION
Allow publishing a list of repositories with different components
to a single prefix